### PR TITLE
fix(web): resolve reviewed admin regressions

### DIFF
--- a/app/(admin)/contracts/page.tsx
+++ b/app/(admin)/contracts/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, Suspense } from "react";
 import { useSearchParams } from "next/navigation";
 import {
+  Alert,
   Box,
   CircularProgress,
   Chip,
@@ -134,6 +135,10 @@ function formatDateTime(iso?: string): string {
   return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
 }
 
+function getContractCanonicalId(row: ContractRow): string | null {
+  return row.contractId ?? row.id ?? null;
+}
+
 // ─────────────────────────────────────────────
 // 메인 컴포넌트 내부 로직 (Suspense용)
 // ─────────────────────────────────────────────
@@ -175,6 +180,7 @@ function ContractsContent() {
   });
 
   const contracts: ContractRow[] = contractsData || [];
+  const listError = error instanceof Error ? error.message : "계약 목록을 불러오지 못했습니다.";
 
   // 드로어 전용 상태
   const [selectedId, setSelectedId] = useState<string | null>(null);
@@ -189,8 +195,9 @@ function ContractsContent() {
         (c.lesson as any)?.id === lessonIdParam || 
         (c as any).lessonId === lessonIdParam
       );
-      if (match) {
-        setSelectedId(match.id);
+      const canonicalId = match ? getContractCanonicalId(match) : null;
+      if (canonicalId) {
+        setSelectedId(canonicalId);
       }
     }
   }, [lessonIdParam, contracts, selectedId]);
@@ -398,6 +405,10 @@ function ContractsContent() {
         <Box display="flex" justifyContent="center" py={8}>
           <CircularProgress />
         </Box>
+      ) : error ? (
+        <Alert severity="error" sx={{ borderRadius: "16px 0 16px 16px" }}>
+          {listError}
+        </Alert>
       ) : (
         <TableContainer component={SurfaceCard}>
           <Table>
@@ -420,7 +431,7 @@ function ContractsContent() {
                 </TableRow>
               ) : (
                 filtered.map((row) => {
-                  const cId = row.contractId ?? row.id;
+                  const cId = getContractCanonicalId(row) ?? `contract-row-${row.contractNumber ?? row.createdAt ?? "unknown"}`;
                   const rowStatus = row.status as ContractStatus;
                   return (
                     <TableRow key={cId} hover>

--- a/app/(admin)/dashboard/page.tsx
+++ b/app/(admin)/dashboard/page.tsx
@@ -130,27 +130,32 @@ export default function DashboardPage() {
         return { hasRecsCount: 0, topRecReadyCount: 0, firstLessonIdWithRec: null };
       }
 
-      let hasRecsCount = 0;
-      let topRecReadyCount = 0;
-      let firstLessonIdWithRec: string | null = null;
-
-      const promises = unassignedLessons.map(async (lesson: LessonRow) => {
+      const results = await Promise.all(unassignedLessons.map(async (lesson: LessonRow) => {
         try {
           const data = await apiClient.getRecommendations(lesson.lessonId);
           const list = Array.isArray(data) ? data : Array.isArray(data?.data) ? data.data : [];
-          if (list.length > 0) {
-            if (!firstLessonIdWithRec) firstLessonIdWithRec = lesson.lessonId;
-            hasRecsCount++;
-            if (list[0].score >= 70 || list[0].confidenceLabel) {
-              topRecReadyCount++;
-            }
-          }
-        } catch (e) {
-          // 무시
-        }
-      });
+          const hasRecommendations = list.length > 0;
+          const topRecommendationReady =
+            hasRecommendations && Boolean(list[0].score >= 70 || list[0].confidenceLabel);
 
-      await Promise.all(promises);
+          return {
+            lessonId: lesson.lessonId,
+            hasRecommendations,
+            topRecommendationReady,
+          };
+        } catch (e) {
+          return {
+            lessonId: lesson.lessonId,
+            hasRecommendations: false,
+            topRecommendationReady: false,
+          };
+        }
+      }));
+
+      const hasRecsCount = results.filter((result) => result.hasRecommendations).length;
+      const topRecReadyCount = results.filter((result) => result.topRecommendationReady).length;
+      const firstLessonIdWithRec =
+        results.find((result) => result.hasRecommendations)?.lessonId ?? null;
 
       return { hasRecsCount, topRecReadyCount, firstLessonIdWithRec };
     },

--- a/app/(admin)/schedules/lessons/create/page.tsx
+++ b/app/(admin)/schedules/lessons/create/page.tsx
@@ -10,6 +10,7 @@ import { ArrowBack, Save, AddBox, Search, CheckCircle } from "@mui/icons-materia
 
 // 💡 전담 우체국 임포트!
 import { apiClient } from "@/src/lib/apiClient";
+import { localDateTimeToUtcIso } from "@/src/lib/dateTime";
 
 export default function CreateLessonPage() {
   const router = useRouter();
@@ -34,7 +35,14 @@ export default function CreateLessonPage() {
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target;
-    setFormData((prev) => ({ ...prev, [name]: value }));
+    setFormData((prev) => ({
+      ...prev,
+      [name]: value,
+      ...(name === "startsAt" || name === "endsAt" ? { instructorId: "" } : {}),
+    }));
+    if (name === "startsAt" || name === "endsAt") {
+      setAvailableInstructors([]);
+    }
   };
 
   // 💡 DB 수업 장소 목록 조회
@@ -75,10 +83,16 @@ export default function CreateLessonPage() {
   // 💡 가용 강사 조회 (apiClient로 교체)
   useEffect(() => {
     const fetchInstructors = async () => {
-      if (!formData.startsAt || !formData.endsAt) return;
+      if (!formData.startsAt || !formData.endsAt) {
+        setAvailableInstructors([]);
+        return;
+      }
       const start = new Date(formData.startsAt);
       const end = new Date(formData.endsAt);
-      if (start >= end) return;
+      if (start >= end) {
+        setAvailableInstructors([]);
+        return;
+      }
 
       setIsFetchingInstructors(true);
       try {
@@ -111,8 +125,8 @@ export default function CreateLessonPage() {
       // 💡 1. 백엔드 요구사항에 맞춘 통합 Payload
       const payload = {
         ...formData,
-        startsAt: new Date(formData.startsAt).toISOString(),
-        endsAt: new Date(formData.endsAt).toISOString(),
+        startsAt: localDateTimeToUtcIso(formData.startsAt),
+        endsAt: localDateTimeToUtcIso(formData.endsAt),
         payAmount: Number(formData.payAmount),
         studentCount: Number(formData.studentCount),
         // DB 수업지 ID 및 위치 데이터 추가

--- a/app/(admin)/schedules/lessons/import/page.tsx
+++ b/app/(admin)/schedules/lessons/import/page.tsx
@@ -18,6 +18,10 @@ import SurfaceCard from "@/src/components/admin/SurfaceCard";
 import AtomButton from "@/src/components/atoms/AtomButton";
 import AtomInput from "@/src/components/atoms/AtomInput";
 import { apiClient } from "@/src/lib/apiClient";
+import {
+  localDateTimeToUtcIso,
+  utcIsoToLocalDateTimeInputValue,
+} from "@/src/lib/dateTime";
 
 export default function DocumentImportPage() {
   const router = useRouter();
@@ -83,8 +87,8 @@ export default function DocumentImportPage() {
         contractTitle: parsed.contractTitle || "",
         companyName: parsed.companyName || "",
         lectureTitle: parsed.lectureTitle || "",
-        startsAt: parsed.startsAt ? parsed.startsAt.slice(0, 16) : "", // datetime-local 형식 (YYYY-MM-DDTHH:mm)
-        endsAt: parsed.endsAt ? parsed.endsAt.slice(0, 16) : "",
+        startsAt: utcIsoToLocalDateTimeInputValue(parsed.startsAt),
+        endsAt: utcIsoToLocalDateTimeInputValue(parsed.endsAt),
         venueName: parsed.venueName || "",
         region: parsed.region || "",
         payAmount: parsed.payAmount ? String(parsed.payAmount) : "",
@@ -115,6 +119,8 @@ export default function DocumentImportPage() {
     try {
       const parsedJson = {
         ...formData,
+        startsAt: localDateTimeToUtcIso(formData.startsAt),
+        endsAt: localDateTimeToUtcIso(formData.endsAt),
         payAmount: formData.payAmount ? Number(formData.payAmount) : null,
       };
 

--- a/app/(admin)/schedules/lessons/page.tsx
+++ b/app/(admin)/schedules/lessons/page.tsx
@@ -153,24 +153,10 @@ export default function ClassManagementPage() {
   const { data: instructorsData, isLoading: isFetchingInstructors } = useQuery({
     queryKey: ["instructors", "available", formData.startsAt, formData.endsAt],
     queryFn: async () => {
-      const token = localStorage.getItem("accessToken");
-      const apiUrl = process.env.NEXT_PUBLIC_API_BASE_URL;
-
-      if (!token || !apiUrl) {
-        throw new Error("가용 강사 조회에 필요한 인증 정보가 없습니다.");
-      }
-
-      const response = await fetch(
-        `${apiUrl}/lessons/available-instructors?startsAt=${start.toISOString()}&endsAt=${end.toISOString()}`,
-        { headers: { Authorization: `Bearer ${token}` } },
+      const data = await apiClient.getAvailableInstructors(
+        start.toISOString(),
+        end.toISOString(),
       );
-
-      if (!response.ok) {
-        const errorData = await response.json().catch(() => ({}));
-        throw new Error(errorData.message || "가용 강사 조회 실패");
-      }
-
-      const data = await response.json();
       return Array.isArray(data) ? data : data.data || [];
     },
     enabled: isDateValidForInstructors,
@@ -211,13 +197,6 @@ export default function ClassManagementPage() {
 
   const createLessonMutation = useMutation({
     mutationFn: async () => {
-      const token = localStorage.getItem("accessToken");
-      const apiUrl = process.env.NEXT_PUBLIC_API_BASE_URL;
-
-      if (!token || !apiUrl) {
-        throw new Error("수업 생성에 필요한 인증 정보가 없습니다.");
-      }
-
       const createPayload = {
         lectureTitle: formData.lectureTitle,
         startsAt: new Date(formData.startsAt).toISOString(),
@@ -231,37 +210,11 @@ export default function ClassManagementPage() {
         deliveryNotes: formData.deliveryNotes || undefined,
       };
 
-      const createResponse = await fetch(`${apiUrl}/lessons`, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${token}`,
-        },
-        body: JSON.stringify(createPayload),
-      });
-
-      if (!createResponse.ok) {
-        const errorData = await createResponse.json().catch(() => ({}));
-        throw new Error(errorData.message || `수업 생성 실패 (${createResponse.status})`);
-      }
-
-      const createdData = await createResponse.json();
+      const createdData = await apiClient.createLesson(createPayload);
       const createdLesson: LessonRow = createdData.data || createdData;
 
       if (formData.instructorId) {
-        const assignResponse = await fetch(`${apiUrl}/lessons/${createdLesson.lessonId}/assign`, {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: `Bearer ${token}`,
-          },
-          body: JSON.stringify({ instructorId: formData.instructorId }),
-        });
-
-        if (!assignResponse.ok) {
-          const errorData = await assignResponse.json().catch(() => ({}));
-          throw new Error(errorData.message || "수업 생성 후 강사 요청에 실패했습니다.");
-        }
+        await apiClient.assignInstructor(createdLesson.lessonId, formData.instructorId);
       }
     },
     onSuccess: () => {
@@ -364,7 +317,7 @@ export default function ClassManagementPage() {
             </TableRow>
           </TableHead>
           <TableBody>
-            {classes.map((lesson: any) => {
+            {filteredClasses.map((lesson: any) => {
               const location = lesson.museum || lesson.venueName || lesson.region || "-";
               const instructor = lesson.requestedInstructorId || "미배정";
               

--- a/app/(admin)/settlements/page.tsx
+++ b/app/(admin)/settlements/page.tsx
@@ -88,6 +88,20 @@ function formatTime(iso: string): string {
   return `${pad(d.getHours())}:${pad(d.getMinutes())}`;
 }
 
+function getSettlementRowKey(row: SettlementMonthly): string {
+  const lessonIds = (row.items ?? [])
+    .map((item) => item.lessonId)
+    .filter(Boolean)
+    .sort()
+    .join(",");
+
+  return [
+    row.month,
+    row.instructorId ?? row.instructorName ?? "unknown-instructor",
+    lessonIds || "no-lessons",
+  ].join(":");
+}
+
 // ─────────────────────────────────────────────
 // 메인 컴포넌트
 // ─────────────────────────────────────────────
@@ -239,7 +253,7 @@ export default function SettlementPage() {
             </TableHead>
             <TableBody>
               {settlements.map((row) => {
-                const rowKey = `${row.instructorId ?? row.month}-${row.month}`;
+                const rowKey = getSettlementRowKey(row);
                 const isExpanded = expandedRows[rowKey] ?? false;
                 const bonusStr = manualBonus[rowKey] ?? "";
                 const bonus = Number(bonusStr) || 0;

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -13,7 +13,7 @@ import AdminPanelSettingsRoundedIcon from "@mui/icons-material/AdminPanelSetting
 import ArrowOutwardRoundedIcon from "@mui/icons-material/ArrowOutwardRounded";
 import LockOutlinedIcon from "@mui/icons-material/LockOutlined";
 import { useRouter } from "next/navigation";
-import { apiClient } from "@/src/lib/apiClient";
+import { apiClient, persistAuthSession } from "@/src/lib/apiClient";
 
 import SurfaceCard from "@/src/components/admin/SurfaceCard";
 import AtomBadge from "@/src/components/atoms/AtomBadge";
@@ -51,13 +51,8 @@ export default function LoginPage() {
       // const data = await apiClient.postAuthGoogle(email);
       const data = await apiClient.postAuthDemo(email);
       
-      localStorage.setItem("accessToken", data.accessToken);
-      if (data.refreshToken) {
-        localStorage.setItem("refreshToken", data.refreshToken);
-      }
+      persistAuthSession(data.accessToken, data.refreshToken);
       localStorage.setItem("user", JSON.stringify(data.user || {}));
-
-      document.cookie = `accessToken=${data.accessToken}; path=/; max-age=3600;`;
 
       router.push("/dashboard");
     } catch (error: any) {

--- a/middleware.ts
+++ b/middleware.ts
@@ -3,18 +3,19 @@ import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 
 export function middleware(request: NextRequest) {
-  // 쿠키에서 accessToken 확인
-  const token = request.cookies.get('accessToken')?.value;
-  
-  const isLoginPage = request.nextUrl.pathname.startsWith('/login');
+  const pathname = request.nextUrl.pathname;
+  const accessToken = request.cookies.get('accessToken')?.value;
+  const refreshToken = request.cookies.get('refreshToken')?.value;
+  const hasSession = Boolean(accessToken || refreshToken);
+  const isLoginPage = pathname.startsWith('/login');
 
   // 토큰이 없는데 로그인 페이지가 아닌 곳(보호 라우트)을 가려고 하면 쫓아냄!
-  if (!token && !isLoginPage) {
+  if (!hasSession && !isLoginPage) {
     return NextResponse.redirect(new URL('/login', request.url));
   }
 
   // 토큰이 있는데 로그인 페이지를 가려고 하면 대시보드로 튕겨냄!
-  if (token && isLoginPage) {
+  if (hasSession && isLoginPage) {
     return NextResponse.redirect(new URL('/dashboard', request.url));
   }
 
@@ -23,5 +24,5 @@ export function middleware(request: NextRequest) {
 
 // 미들웨어가 감시할 경로 설정 (api, 정적 파일, 이미지 등은 제외)
 export const config = {
-  matcher: ['/((?!api|_next/static|_next/image|favicon.ico).*)'],
+  matcher: ['/((?!api|_next/static|_next/image|favicon.ico|.*\\..*).*)'],
 };

--- a/src/components/AssignmentModal.tsx
+++ b/src/components/AssignmentModal.tsx
@@ -21,6 +21,7 @@ import AtomBadge from "@/src/components/atoms/AtomBadge";
 import AtomButton from "@/src/components/atoms/AtomButton";
 import AtomInput from "@/src/components/atoms/AtomInput";
 import { apiClient } from "@/src/lib/apiClient";
+import { localDateAndTimeToUtcIso } from "@/src/lib/dateTime";
 
 interface AssignmentModalProps {
   open: boolean;
@@ -29,11 +30,6 @@ interface AssignmentModalProps {
 }
 
 const steps = ["기본 정보/시간", "장소 및 지도안", "강사 배정"];
-
-const convertToUTCISO8601 = (date: string, time: string): string => {
-  if (!date || !time) return "";
-  return `${date}T${time}:00Z`;
-};
 
 const START_TIME_OPTIONS = Array.from({ length: (22 - 8) * 2 + 1 }, (_, index) => {
   const hours = 8 + Math.floor(index / 2);
@@ -73,8 +69,14 @@ export default function AssignmentModal({ open, onClose, onSuccess }: Assignment
   const [selectedInstructorId, setSelectedInstructorId] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
 
+  const clearInstructorSelection = () => {
+    setSelectedInstructorId("");
+    setAvailableInstructors([]);
+  };
+
   const handleStartTimeChange = (value: string) => {
     setStartTime(value);
+    clearInstructorSelection();
     if (!value) {
       setEndTime("");
       return;
@@ -82,6 +84,21 @@ export default function AssignmentModal({ open, onClose, onSuccess }: Assignment
     const [hourString, minuteString] = value.split(":");
     const nextHour = (parseInt(hourString, 10) + 2) % 24;
     setEndTime(`${nextHour.toString().padStart(2, "0")}:${minuteString}`);
+  };
+
+  const handleLessonDateChange = (value: string) => {
+    setLessonDate(value);
+    clearInstructorSelection();
+  };
+
+  const handleEndTimeChange = (value: string) => {
+    setEndTime(value);
+    clearInstructorSelection();
+  };
+
+  const handleVenueSelect = (venue: any) => {
+    setSelectedVenue(venue);
+    clearInstructorSelection();
   };
 
   const resetState = () => {
@@ -93,6 +110,7 @@ export default function AssignmentModal({ open, onClose, onSuccess }: Assignment
     setSearchQuery("");
     setSearchResults([]);
     setSelectedVenue(null);
+    setAvailableInstructors([]);
     setGuideUrl("");
     setRegion("");
     setMuseum("");
@@ -125,8 +143,8 @@ export default function AssignmentModal({ open, onClose, onSuccess }: Assignment
   const fetchAvailableInstructors = async () => {
     setIsFetchingInstructors(true);
     try {
-      const startsAt = convertToUTCISO8601(lessonDate, startTime);
-      const endsAt = convertToUTCISO8601(lessonDate, endTime);
+      const startsAt = localDateAndTimeToUtcIso(lessonDate, startTime);
+      const endsAt = localDateAndTimeToUtcIso(lessonDate, endTime);
       const data = await apiClient.getAvailableInstructors(startsAt, endsAt);
       setAvailableInstructors(Array.isArray(data) ? data : data.data || []);
     } catch (error) {
@@ -151,8 +169,8 @@ export default function AssignmentModal({ open, onClose, onSuccess }: Assignment
     try {
       const payload = {
         lectureTitle,
-        startsAt: convertToUTCISO8601(lessonDate, startTime),
-        endsAt: convertToUTCISO8601(lessonDate, endTime),
+        startsAt: localDateAndTimeToUtcIso(lessonDate, startTime),
+        endsAt: localDateAndTimeToUtcIso(lessonDate, endTime),
         venueName: selectedVenue.venueName,
         venueAddress: selectedVenue.venueAddress,
         venueLat: selectedVenue.venueLat,
@@ -214,12 +232,12 @@ export default function AssignmentModal({ open, onClose, onSuccess }: Assignment
         <AtomInput type="number" label="배정 학생 수(명)" value={studentCount} onChange={(e) => setStudentCount(e.target.value)} placeholder="예: 10" fullWidth />
       </Stack>
 
-      <AtomInput type="date" label="날짜" value={lessonDate} onChange={(e) => setLessonDate(e.target.value)} fullWidth required />
+      <AtomInput type="date" label="날짜" value={lessonDate} onChange={(e) => handleLessonDateChange(e.target.value)} fullWidth required />
       <Stack direction={{ xs: "column", sm: "row" }} spacing={2}>
         <AtomInput select label="시작시간" value={startTime} onChange={(e) => handleStartTimeChange(e.target.value)} fullWidth required>
           {START_TIME_OPTIONS.map((opt) => (<MenuItem key={opt} value={opt}>{opt}</MenuItem>))}
         </AtomInput>
-        <AtomInput select label="종료시간" value={endTime} onChange={(e) => setEndTime(e.target.value)} fullWidth required>
+        <AtomInput select label="종료시간" value={endTime} onChange={(e) => handleEndTimeChange(e.target.value)} fullWidth required>
           {END_TIME_OPTIONS.map((opt) => (<MenuItem key={opt} value={opt}>{opt === "24:00" ? "24:00 (자정)" : opt}</MenuItem>))}
         </AtomInput>
       </Stack>
@@ -249,7 +267,7 @@ export default function AssignmentModal({ open, onClose, onSuccess }: Assignment
           {searchResults.map((place) => (
             <Box
               key={place.kakaoPlaceId}
-              onClick={() => setSelectedVenue(place)}
+              onClick={() => handleVenueSelect(place)}
               sx={{
                 p: 1.5, cursor: "pointer", borderRadius: 1,
                 bgcolor: selectedVenue?.kakaoPlaceId === place.kakaoPlaceId ? "#FFF8E1" : "transparent",

--- a/src/components/ChatDrawer.tsx
+++ b/src/components/ChatDrawer.tsx
@@ -120,6 +120,19 @@ export default function ChatDrawer({ open, onClose, onUnreadCountChange }: ChatD
     activeRoomRef.current = activeRoom;
   }, [activeRoom]);
 
+  const clearActiveRoom = useCallback(() => {
+    const currentRoom = activeRoomRef.current;
+    if (currentRoom) {
+      socketRef.current?.emit("leave_room", { roomId: currentRoom.roomId });
+    }
+
+    activeRoomRef.current = null;
+    setActiveRoom(null);
+    setMessages([]);
+    setNextCursor(null);
+    setInputText("");
+  }, []);
+
   // ── WebSocket 연결
   useEffect(() => {
     const token = getToken();
@@ -263,12 +276,14 @@ export default function ChatDrawer({ open, onClose, onUnreadCountChange }: ChatD
   };
 
   const handleBack = () => {
-    if (activeRoom) {
-      socketRef.current?.emit("leave_room", { roomId: activeRoom.roomId });
-    }
-    setActiveRoom(null);
-    setMessages([]);
+    clearActiveRoom();
     queryClient.invalidateQueries({ queryKey: queryKeys.chat.rooms });
+  };
+
+  const handleDrawerClose = () => {
+    clearActiveRoom();
+    queryClient.invalidateQueries({ queryKey: queryKeys.chat.rooms });
+    onClose();
   };
 
   const activeRoomName = activeRoom ? getRoomDisplayName(activeRoom) : "";
@@ -277,7 +292,7 @@ export default function ChatDrawer({ open, onClose, onUnreadCountChange }: ChatD
     <Drawer 
       anchor="right" 
       open={open} 
-      onClose={onClose}
+      onClose={handleDrawerClose}
       PaperProps={{
         sx: {
           width: { xs: '100vw', sm: 440 },
@@ -321,8 +336,8 @@ export default function ChatDrawer({ open, onClose, onUnreadCountChange }: ChatD
               )}
             </Box>
           </Stack>
-          <IconButton 
-            onClick={onClose} 
+          <IconButton
+            onClick={handleDrawerClose}
             size="small"
             sx={{ bgcolor: 'white', border: '1px solid #eee' }}
           >

--- a/src/lib/apiClient.ts
+++ b/src/lib/apiClient.ts
@@ -3,13 +3,71 @@ import { ApiError } from "./apiError";
 
 // 백엔드 명세에는 API_URL이지만, 기존에 쓰시던 API_BASE_URL도 호환되게 함.
 const BASE_URL = process.env.NEXT_PUBLIC_API_URL || process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:3000";
+const ACCESS_TOKEN_COOKIE = "accessToken";
+const REFRESH_TOKEN_COOKIE = "refreshToken";
+const ACCESS_TOKEN_MAX_AGE = 60 * 60;
+const REFRESH_TOKEN_MAX_AGE = 60 * 60 * 24 * 30;
+
+const setCookie = (name: string, value: string, maxAge: number) => {
+  if (typeof document === "undefined") return;
+  document.cookie = `${name}=${encodeURIComponent(value)}; path=/; max-age=${maxAge}; SameSite=Lax;`;
+};
+
+const clearCookie = (name: string) => {
+  if (typeof document === "undefined") return;
+  document.cookie = `${name}=; path=/; max-age=0; SameSite=Lax;`;
+};
+
+export const persistAuthSession = (accessToken: string, refreshToken?: string | null) => {
+  if (typeof window === "undefined") return;
+
+  localStorage.setItem(ACCESS_TOKEN_COOKIE, accessToken);
+  setCookie(ACCESS_TOKEN_COOKIE, accessToken, ACCESS_TOKEN_MAX_AGE);
+
+  if (refreshToken) {
+    localStorage.setItem(REFRESH_TOKEN_COOKIE, refreshToken);
+    setCookie(REFRESH_TOKEN_COOKIE, refreshToken, REFRESH_TOKEN_MAX_AGE);
+  }
+};
+
+export const clearAuthSession = () => {
+  if (typeof window === "undefined") return;
+
+  localStorage.removeItem(ACCESS_TOKEN_COOKIE);
+  localStorage.removeItem(REFRESH_TOKEN_COOKIE);
+  localStorage.removeItem("user");
+  clearCookie(ACCESS_TOKEN_COOKIE);
+  clearCookie(REFRESH_TOKEN_COOKIE);
+};
 
 const getToken = (): string | null => {
   if (typeof window !== "undefined") {
-    return localStorage.getItem("accessToken");
+    return localStorage.getItem(ACCESS_TOKEN_COOKIE);
   }
   return null;
 };
+
+async function parseResponseBody(response: Response): Promise<unknown> {
+  if (response.status === 204 || response.status === 205) {
+    return null;
+  }
+
+  const contentLength = response.headers.get("content-length");
+  if (contentLength === "0") {
+    return null;
+  }
+
+  const text = await response.text();
+  if (!text) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
 
 async function request<T>(endpoint: string, options: RequestInit = {}): Promise<T> {
   const url = `${BASE_URL}${endpoint}`;
@@ -26,7 +84,7 @@ async function request<T>(endpoint: string, options: RequestInit = {}): Promise<
   let response = await fetch(url, { ...options, headers });
 
   if (response.status === 401 && typeof window !== "undefined") {
-    const refreshToken = localStorage.getItem("refreshToken");
+    const refreshToken = localStorage.getItem(REFRESH_TOKEN_COOKIE);
     
     if (refreshToken) {
       try {
@@ -38,12 +96,17 @@ async function request<T>(endpoint: string, options: RequestInit = {}): Promise<
         });
 
         if (refreshRes.ok) {
-          const refreshData = await refreshRes.json();
-          const newAccess = refreshData.data?.accessToken || refreshData.accessToken;
+          const refreshData = await parseResponseBody(refreshRes) as
+            | { data?: { accessToken?: string; refreshToken?: string }; accessToken?: string; refreshToken?: string }
+            | null;
+          const newAccess = refreshData?.data?.accessToken || refreshData?.accessToken;
+          const newRefresh = refreshData?.data?.refreshToken || refreshData?.refreshToken || refreshToken;
+
+          if (!newAccess) {
+            throw new Error("Refresh response missing access token");
+          }
           
-          // 새 토큰 저장 (로컬 + 쿠키)
-          localStorage.setItem("accessToken", newAccess);
-          document.cookie = `accessToken=${newAccess}; path=/; max-age=3600;`;
+          persistAuthSession(newAccess, newRefresh);
           
           // 막혔던 원래 요청에 새 토큰 끼워서 다시 보내기!
           headers.set("Authorization", `Bearer ${newAccess}`);
@@ -53,25 +116,36 @@ async function request<T>(endpoint: string, options: RequestInit = {}): Promise<
         }
       } catch (err) {
         // 재발급도 실패하면 토큰 다 지우고 쫓아내기
-        localStorage.clear();
-        document.cookie = "accessToken=; path=/; max-age=0;";
+        clearAuthSession();
         window.location.href = "/login";
       }
     } else {
       // 리프레시 토큰조차 없으면 쫓아내기
-      localStorage.clear();
-      document.cookie = "accessToken=; path=/; max-age=0;";
+      clearAuthSession();
       window.location.href = "/login";
     }
   }
 
   if (!response.ok) {
-    const errorData = await response.json().catch(() => ({}));
-    throw new ApiError(response.status, errorData.message || "API Error", errorData.code);
+    const errorData = await parseResponseBody(response);
+    if (errorData && typeof errorData === "object" && !Array.isArray(errorData)) {
+      const normalized = errorData as { message?: string; code?: string };
+      throw new ApiError(response.status, normalized.message || "API Error", normalized.code);
+    }
+
+    throw new ApiError(
+      response.status,
+      typeof errorData === "string" ? errorData : "API Error",
+    );
   }
 
-  const data = await response.json();
-  return data.data !== undefined ? data.data : data;
+  const data = await parseResponseBody(response);
+
+  if (data && typeof data === "object" && !Array.isArray(data) && "data" in data) {
+    return (data as { data: T }).data;
+  }
+
+  return data as T;
 }
 
 // 컴포넌트에서 가져다 쓸 실제 API 메서드들
@@ -90,8 +164,7 @@ export const apiClient = {
 
   logout: () => {
     if (typeof window !== "undefined") {
-      localStorage.clear();
-      document.cookie = "accessToken=; path=/; max-age=0;";
+      clearAuthSession();
       window.location.href = "/login";
     }
   },

--- a/src/lib/dateTime.ts
+++ b/src/lib/dateTime.ts
@@ -1,0 +1,26 @@
+const padDateTimePart = (value: number) => String(value).padStart(2, "0");
+
+export function localDateTimeToUtcIso(localDateTime: string): string {
+  if (!localDateTime) return "";
+  return new Date(localDateTime).toISOString();
+}
+
+export function localDateAndTimeToUtcIso(date: string, time: string): string {
+  if (!date || !time) return "";
+  return localDateTimeToUtcIso(`${date}T${time}`);
+}
+
+export function utcIsoToLocalDateTimeInputValue(value: string | null | undefined): string {
+  if (!value) return "";
+
+  const parsedDate = new Date(value);
+  if (Number.isNaN(parsedDate.getTime())) {
+    return value.slice(0, 16);
+  }
+
+  return [
+    parsedDate.getFullYear(),
+    padDateTimePart(parsedDate.getMonth() + 1),
+    padDateTimePart(parsedDate.getDate()),
+  ].join("-") + `T${padDateTimePart(parsedDate.getHours())}:${padDateTimePart(parsedDate.getMinutes())}`;
+}


### PR DESCRIPTION
## Summary
- fix auth/api session handling and empty success response parsing
- fix lesson datetime conversion, import review drift, and stale instructor selection
- fix chat drawer unread regression and lesson list search/env regressions
- fix contracts/dashboard/settlements edge cases found during review

## Verification
- `git diff --check`
- `./node_modules/.bin/tsc --noEmit` *(fails in current repo state due existing `@tanstack/react-query` resolution and pre-existing implicit-any issues)*

Closes #136
Closes #137
Closes #138
Closes #139
Closes #140
Closes #141
Closes #142
